### PR TITLE
Implement path configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ results
 
 npm-debug.log
 node_modules
+
+.idea

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ var express = require('express');
 
 var app = express();
 ...
-app.use(health.ping); // this is the only addition
+app.use(health.ping()); // this is the only addition
 app.use(app.router);
 ...
 
 app.listen(3000);
 ```
+
 
 Once you launch your express application, it will add a new **/ping** endpoint to check the app status. If you **GET http://localhost:3000/ping** you will receive the following information:
 
@@ -63,6 +64,14 @@ Once you launch your express application, it will add a new **/ping** endpoint t
   }
 }
 ```
+Configuration
+-------------
+By default, a `/ping` endpoint will be added to your routes, but you can pass the _ping_ endpoint to the middeware simply doing
+
+```js
+app.use(health.ping('/custompath'));
+```
+
 
 TODO
 ----

--- a/examples/server.js
+++ b/examples/server.js
@@ -2,7 +2,7 @@ var health = require('../index');
 var express = require('express');
 
 var app = express();
-app.use(health.ping)
+app.use(health.ping())
 app.use(app.router);
 
 app.listen(3000);

--- a/lib/health.js
+++ b/lib/health.js
@@ -1,9 +1,12 @@
 var os = require('os');
 var pjson = require(process.cwd() + '/package.json');
+var DEFAULT_PATH = '/ping';
 
-module.exports.ping = function(req, res, next) {
-  if (req.path === '/ping') {
-    res.send({
+module.exports.ping = function pingMiddlewareWrapper(path) {
+  path = path || DEFAULT_PATH;
+  return function pingMiddleware(req, res, next) {
+    if (req.path === path) {
+      res.json({
         timestamp: Date.now(),
         uptime: process.uptime(),
         pid: process.pid,
@@ -14,16 +17,16 @@ module.exports.ping = function(req, res, next) {
         platform: process.platform,
         argv: process.argv,
         application: {
-            name: pjson.name,
-            version: pjson.version
+          name: pjson.name,
+          version: pjson.version
         },
         os: {
-            hostname: os.hostname(),
-            uptime: os.uptime()
+          hostname: os.hostname(),
+          uptime: os.uptime()
         }
-    }, 200);
-    res.end();
-  } else {
-    next();
-  }
-}
+      });
+    } else {
+      next();
+    }
+  };
+};


### PR DESCRIPTION
Allow to specify where the middleware should be listening
Return 'application/json' content-type with the response headers

fixes #1
