### PR TITLE
replace node-df with node-df-win-posix to support windows

### DIFF
--- a/lib/health.js
+++ b/lib/health.js
@@ -1,5 +1,5 @@
 var os = require('os'),
-    df = require('node-df'),
+    df = require('node-df-win-posix'),
     path = require('path');
 
 function loadMainPackageJSON(attempts) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "git://github.com/palmerabollo/express-ping"
   },
   "author": "Guido García (http://guidogarcia.net)",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "index.js",
   "engines": {
     "node": ">= 0.8.x"
@@ -19,7 +19,9 @@
     "api"
   ],
   "dependencies": {
-    "express": "~3.x || ~4.x",
     "node-df-win-posix": "^0.3.0"
+  },
+  "peerDependencies": {
+    "express": "~3.x || ~4.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   ],
   "dependencies": {
     "express": "~3.x || ~4.x",
-    "node-df": "^0.1.1"
+    "node-df-win-posix": "^0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "git://github.com/palmerabollo/express-ping"
   },
   "author": "Guido García (http://guidogarcia.net)",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "index.js",
   "engines": {
     "node": ">= 0.8.x"
@@ -20,6 +20,6 @@
   ],
   "dependencies": {
     "express": "~3.x || ~4.x",
-    "node-df-win-posix": "^0.2.0"
+    "node-df-win-posix": "^0.3.0"
   }
 }


### PR DESCRIPTION
Since node-df is not active for a long time, I have to create another package node-df-win-posix to support windows with the same disk info.