### PR TITLE
Removing require.main due to Typescript compatability

### DIFF
--- a/lib/health.js
+++ b/lib/health.js
@@ -9,7 +9,7 @@ function loadMainPackageJSON(attempts) {
     }
     var mainPath = attempts === 1 ? './' : Array(attempts).join("../");
     try {
-        return require.main.require(mainPath + 'package.json');
+        return require(mainPath + 'package.json');
     } catch (e) {
         return loadMainPackageJSON(attempts + 1);
     }


### PR DESCRIPTION
I had to remove the line require.main on line12. I could not get it to work with typescript